### PR TITLE
Update library version for stitch data in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Quick Start
 Leiningen:
 
 ```clojure
-[com.stitchdata/clojure-stitch-client "0.1.6"]
+[com.stitchdata/clojure-stitch-client "0.5.9"]
 ```
 
 ### Require the Library


### PR DESCRIPTION
Currently says 0.1.6 which failed with an unknown host error for pipeline-gateway.rjmetrics.com.